### PR TITLE
Note page background functionality implemented

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-
+    <uses-permission android:name = "android.permission.WRITE_EXTERNAL_STORAGE"/>
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/allan/boardbuddies/EditActivity.java
+++ b/app/src/main/java/com/allan/boardbuddies/EditActivity.java
@@ -2,6 +2,8 @@ package com.allan.boardbuddies;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.EditText;
@@ -12,6 +14,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 public class EditActivity extends AppCompatActivity {
+    private EditText editTextTitle;
+    private EditText editTextContent;
+    private Bundle extras;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -19,21 +24,31 @@ public class EditActivity extends AppCompatActivity {
         setContentView(R.layout.activity_edit);
         Toolbar toolbar = findViewById(R.id.edit_note_toolbar);
         toolbar.setNavigationOnClickListener(v -> {
-            saveTextNote();
+            //if there no extras or the extras are changed, saveTextNote()
+            // delete old text note only if there are extra and extras are changed
+            if (extras == null){
+                saveTextNote();
+            } else if (!extras.getString("TITLE").equals(editTextTitle.getText().toString()) || !extras.getString("CONTENT").equals(editTextContent.getText().toString())) {
+                saveTextNote();
+                getApplicationContext().deleteFile(extras.getString("NAME"));
+            }
             onBackPressed();
         });
 
         View extraView = findViewById(R.id.extra_scrollspace);
-        EditText editTextNoteContent = findViewById(R.id.edit_textnote_content);
-        extraView.setOnClickListener(v -> editTextNoteContent.requestFocus());
-
+        editTextTitle = findViewById(R.id.edit_textnote_title);
+        editTextContent = findViewById(R.id.edit_textnote_content);
+        extras = getIntent().getExtras();
+        if (extras != null){
+            editTextTitle.setText(extras.getString("TITLE"));
+            editTextContent.setText(extras.getString("CONTENT"));
+        }
+        extraView.setOnClickListener(v -> editTextContent.requestFocus());
     }
 
     private void saveTextNote(){
-        EditText editText1 = findViewById(R.id.edit_textnote_title);
-        EditText editText2 = findViewById(R.id.edit_textnote_content);
-        String title = editText1.getText().toString();
-        String content = editText2.getText().toString();
+        String title = editTextTitle.getText().toString();
+        String content = editTextContent.getText().toString();
         if (!title.trim().isEmpty() || !content.trim().isEmpty()){
             String fileName = System.currentTimeMillis() + ".json";
             try {

--- a/app/src/main/java/com/allan/boardbuddies/EditActivity.java
+++ b/app/src/main/java/com/allan/boardbuddies/EditActivity.java
@@ -21,6 +21,7 @@ public class EditActivity extends AppCompatActivity {
     private String localFilename;
     private String localTitle;
     private String localContent;
+    private int localPosition;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -28,13 +29,16 @@ public class EditActivity extends AppCompatActivity {
         setContentView(R.layout.activity_edit);
         Toolbar toolbar = findViewById(R.id.edit_note_toolbar);
         toolbar.setNavigationOnClickListener(v -> {
+            Intent resultIntent = new Intent();
             if (localFilename == null){ //if there is no local file: saveTextNote()
-                saveTextNote();
+                resultIntent.putExtra("addedFilename", saveTextNote());
             } else if (!localTitle.equals(editTextTitle.getText().toString()) || !localContent.equals(editTextContent.getText().toString())) { //if local file has been changed
-                saveTextNote();
+                resultIntent.putExtra("addedFilename", saveTextNote());
+                resultIntent.putExtra("deletedPosition", localPosition);
                 getApplicationContext().deleteFile(localFilename);
             }
-            onBackPressed();
+            setResult(RESULT_OK, resultIntent);
+            finish();
         });
 
         View extraView = findViewById(R.id.extra_scrollspace);
@@ -45,6 +49,7 @@ public class EditActivity extends AppCompatActivity {
             localFilename = getIntent().getExtras().getString("FILENAME");
             localTitle = getIntent().getExtras().getString("TITLE");
             localContent = getIntent().getExtras().getString("CONTENT");
+            localPosition = getIntent().getExtras().getInt("POSITION");
             editTextTitle.setText(localTitle);
             editTextContent.setText(localContent);
         }
@@ -56,7 +61,7 @@ public class EditActivity extends AppCompatActivity {
         });
     }
 
-    private void saveTextNote(){
+    private String saveTextNote(){
         String title = editTextTitle.getText().toString();
         String content = editTextContent.getText().toString();
         if (!title.trim().isEmpty() || !content.trim().isEmpty()){
@@ -71,10 +76,11 @@ public class EditActivity extends AppCompatActivity {
                 FileWriter fileWriter = new FileWriter(file);
                 fileWriter.write(jsonString);
                 fileWriter.close();
+                return fileName;
             } catch (IOException | JSONException e) {
                 e.printStackTrace();
             }
         }
+        return null;
     }
-
 }

--- a/app/src/main/java/com/allan/boardbuddies/EditActivity.java
+++ b/app/src/main/java/com/allan/boardbuddies/EditActivity.java
@@ -2,11 +2,14 @@ package com.allan.boardbuddies;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
-
 import android.os.Bundle;
 import android.view.View;
 import android.widget.EditText;
-import android.widget.ScrollView;
+import org.json.JSONException;
+import org.json.JSONObject;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 
 public class EditActivity extends AppCompatActivity {
 
@@ -14,12 +17,39 @@ public class EditActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_edit);
-        Toolbar toolbar = (Toolbar) findViewById(R.id.edit_note_toolbar);
-        toolbar.setNavigationOnClickListener(v -> onBackPressed());
+        Toolbar toolbar = findViewById(R.id.edit_note_toolbar);
+        toolbar.setNavigationOnClickListener(v -> {
+            saveTextNote();
+            onBackPressed();
+        });
 
         View extraView = findViewById(R.id.extra_scrollspace);
         EditText editTextNoteContent = findViewById(R.id.edit_textnote_content);
         extraView.setOnClickListener(v -> editTextNoteContent.requestFocus());
 
     }
+
+    private void saveTextNote(){
+        EditText editText1 = findViewById(R.id.edit_textnote_title);
+        EditText editText2 = findViewById(R.id.edit_textnote_content);
+        String title = editText1.getText().toString();
+        String content = editText2.getText().toString();
+        if (!title.trim().isEmpty() || !content.trim().isEmpty()){
+            String fileName = System.currentTimeMillis() + ".json";
+            try {
+                JSONObject jsonObject = new JSONObject();
+                jsonObject.put("title", title);
+                jsonObject.put("content", content);
+                String jsonString = jsonObject.toString();
+
+                File file = new File(getFilesDir(), fileName);
+                FileWriter fileWriter = new FileWriter(file);
+                fileWriter.write(jsonString);
+                fileWriter.close();
+            } catch (IOException | JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
 }

--- a/app/src/main/java/com/allan/boardbuddies/EditActivity.java
+++ b/app/src/main/java/com/allan/boardbuddies/EditActivity.java
@@ -57,7 +57,7 @@ public class EditActivity extends AppCompatActivity {
                 jsonObject.put("content", content);
                 String jsonString = jsonObject.toString();
 
-                File file = new File(getFilesDir(), fileName);
+                File file = new File(getApplicationContext().getFilesDir(), fileName);
                 FileWriter fileWriter = new FileWriter(file);
                 fileWriter.write(jsonString);
                 fileWriter.close();

--- a/app/src/main/java/com/allan/boardbuddies/EditActivity.java
+++ b/app/src/main/java/com/allan/boardbuddies/EditActivity.java
@@ -18,7 +18,9 @@ import java.io.IOException;
 public class EditActivity extends AppCompatActivity {
     private EditText editTextTitle;
     private EditText editTextContent;
-    private Bundle extras;
+    private String localFilename;
+    private String localTitle;
+    private String localContent;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -26,13 +28,11 @@ public class EditActivity extends AppCompatActivity {
         setContentView(R.layout.activity_edit);
         Toolbar toolbar = findViewById(R.id.edit_note_toolbar);
         toolbar.setNavigationOnClickListener(v -> {
-            //if there no extras or the extras are changed, saveTextNote()
-            // delete old text note only if there are extra and extras are changed
-            if (extras == null){
+            if (localFilename == null){ //if there is no local file: saveTextNote()
                 saveTextNote();
-            } else if (!extras.getString("TITLE").equals(editTextTitle.getText().toString()) || !extras.getString("CONTENT").equals(editTextContent.getText().toString())) {
+            } else if (!localTitle.equals(editTextTitle.getText().toString()) || !localContent.equals(editTextContent.getText().toString())) { //if local file has been changed
                 saveTextNote();
-                getApplicationContext().deleteFile(extras.getString("NAME"));
+                getApplicationContext().deleteFile(localFilename);
             }
             onBackPressed();
         });
@@ -40,10 +40,13 @@ public class EditActivity extends AppCompatActivity {
         View extraView = findViewById(R.id.extra_scrollspace);
         editTextTitle = findViewById(R.id.edit_textnote_title);
         editTextContent = findViewById(R.id.edit_textnote_content);
-        extras = getIntent().getExtras();
-        if (extras != null){
-            editTextTitle.setText(extras.getString("TITLE"));
-            editTextContent.setText(extras.getString("CONTENT"));
+
+        if (getIntent().getExtras() != null){
+            localFilename = getIntent().getExtras().getString("FILENAME");
+            localTitle = getIntent().getExtras().getString("TITLE");
+            localContent = getIntent().getExtras().getString("CONTENT");
+            editTextTitle.setText(localTitle);
+            editTextContent.setText(localContent);
         }
         extraView.setOnClickListener(v -> {
             editTextContent.requestFocus();

--- a/app/src/main/java/com/allan/boardbuddies/EditActivity.java
+++ b/app/src/main/java/com/allan/boardbuddies/EditActivity.java
@@ -3,9 +3,11 @@ package com.allan.boardbuddies;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -43,7 +45,12 @@ public class EditActivity extends AppCompatActivity {
             editTextTitle.setText(extras.getString("TITLE"));
             editTextContent.setText(extras.getString("CONTENT"));
         }
-        extraView.setOnClickListener(v -> editTextContent.requestFocus());
+        extraView.setOnClickListener(v -> {
+            editTextContent.requestFocus();
+            editTextContent.setSelection(editTextContent.getText().length());
+            InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+            imm.showSoftInput(editTextContent, InputMethodManager.SHOW_IMPLICIT);
+        });
     }
 
     private void saveTextNote(){

--- a/app/src/main/java/com/allan/boardbuddies/Note.java
+++ b/app/src/main/java/com/allan/boardbuddies/Note.java
@@ -4,12 +4,12 @@ package com.allan.boardbuddies;
 public class Note {
     private String title;
     private String content;
-    private String name;
+    private String filename;
 
-    public Note(String title, String content, String name){
+    public Note(String title, String content, String filename){
         this.title = title;
         this.content = content;
-        this.name = name;
+        this.filename = filename;
     }
 
     public String getTitle(){
@@ -19,7 +19,7 @@ public class Note {
         return this.content;
     }
     public String getName(){
-        return this.name;
+        return this.filename;
     }
 
 }

--- a/app/src/main/java/com/allan/boardbuddies/Note.java
+++ b/app/src/main/java/com/allan/boardbuddies/Note.java
@@ -4,13 +4,22 @@ package com.allan.boardbuddies;
 public class Note {
     private String title;
     private String content;
+    private String name;
 
-    public Note(String title, String content){
+    public Note(String title, String content, String name){
         this.title = title;
         this.content = content;
+        this.name = name;
     }
 
     public String getTitle(){
         return this.title;
     }
+    public String getContent(){
+        return this.content;
+    }
+    public String getName(){
+        return this.name;
+    }
+
 }

--- a/app/src/main/java/com/allan/boardbuddies/NoteAdapter.java
+++ b/app/src/main/java/com/allan/boardbuddies/NoteAdapter.java
@@ -9,8 +9,6 @@ import android.view.ViewGroup;
 import android.view.LayoutInflater;
 import android.widget.TextView;
 
-import com.allan.boardbuddies.fragments.NotesFragment;
-
 // binds data to views displayed by RecyclerView
 public class NoteAdapter extends RecyclerView.Adapter<NoteAdapter.NoteViewHolder> {
     private ArrayList<Note> notes;
@@ -43,20 +41,13 @@ public class NoteAdapter extends RecyclerView.Adapter<NoteAdapter.NoteViewHolder
     }
 
     // Allows access to each list item view without needing to lookup every time
-    public static class NoteViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener{
+    public static class NoteViewHolder extends RecyclerView.ViewHolder{
         TextView titleTextView;
-        OnNoteListener onNoteListener;
 
-        public NoteViewHolder(View itemView, OnNoteListener onNoteListener){
+        public NoteViewHolder(View itemView, OnNoteListener onNoteListener) {
             super(itemView);
             titleTextView = itemView.findViewById(R.id.note_title_text);
-            itemView.setOnClickListener(this);
-            this.onNoteListener = onNoteListener;
-        }
-
-        @Override
-        public void onClick(View v){
-            this.onNoteListener.onNoteClick(getBindingAdapterPosition());
+            itemView.setOnClickListener(view -> onNoteListener.onNoteClick(getBindingAdapterPosition()));
         }
     }
 

--- a/app/src/main/java/com/allan/boardbuddies/NoteAdapter.java
+++ b/app/src/main/java/com/allan/boardbuddies/NoteAdapter.java
@@ -9,12 +9,16 @@ import android.view.ViewGroup;
 import android.view.LayoutInflater;
 import android.widget.TextView;
 
+import com.allan.boardbuddies.fragments.NotesFragment;
+
 // binds data to views displayed by RecyclerView
 public class NoteAdapter extends RecyclerView.Adapter<NoteAdapter.NoteViewHolder> {
     private ArrayList<Note> notes;
+    private OnNoteListener onNoteListener;
     //constructor
-    public NoteAdapter(ArrayList<Note> notes){
+    public NoteAdapter(ArrayList<Note> notes, OnNoteListener onNoteListener){
         this.notes = notes;
+        this.onNoteListener = onNoteListener;
     }
 
     //Creates ViewHolder for view (note_item.xml), converts xml to View object, this method runs when no ViewHolders are available
@@ -22,7 +26,7 @@ public class NoteAdapter extends RecyclerView.Adapter<NoteAdapter.NoteViewHolder
     @Override
     public NoteViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         View itemView = LayoutInflater.from(parent.getContext()).inflate(R.layout.note_item, parent, false);
-        return new NoteViewHolder(itemView);
+        return new NoteViewHolder(itemView, this.onNoteListener);
     }
 
     // Prepare view to be added to layout, called after ViewHolder obtained
@@ -39,12 +43,24 @@ public class NoteAdapter extends RecyclerView.Adapter<NoteAdapter.NoteViewHolder
     }
 
     // Allows access to each list item view without needing to lookup every time
-    public static class NoteViewHolder extends RecyclerView.ViewHolder{
+    public static class NoteViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener{
         TextView titleTextView;
+        OnNoteListener onNoteListener;
 
-        public NoteViewHolder(View itemView){
+        public NoteViewHolder(View itemView, OnNoteListener onNoteListener){
             super(itemView);
             titleTextView = itemView.findViewById(R.id.note_title_text);
+            itemView.setOnClickListener(this);
+            this.onNoteListener = onNoteListener;
         }
+
+        @Override
+        public void onClick(View v){
+            this.onNoteListener.onNoteClick(getBindingAdapterPosition());
+        }
+    }
+
+    public interface OnNoteListener{
+        void onNoteClick(int position);
     }
 }

--- a/app/src/main/java/com/allan/boardbuddies/fragments/NotesFragment.java
+++ b/app/src/main/java/com/allan/boardbuddies/fragments/NotesFragment.java
@@ -3,6 +3,7 @@ package com.allan.boardbuddies.fragments;
 import android.content.Intent;
 import android.os.Bundle;
 import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -52,9 +53,12 @@ public class NotesFragment extends Fragment {
 
         View view = inflater.inflate(R.layout.fragment_notes, container, false);
         recyclerView = view.findViewById(R.id.main_recycler_view);
-        recyclerView.setLayoutManager(new LinearLayoutManager(view.getContext()));
+        LinearLayoutManager layoutManager = new LinearLayoutManager(view.getContext());
+        recyclerView.setLayoutManager(layoutManager);
         adapter = new NoteAdapter(notes);
         recyclerView.setAdapter(adapter);
+        recyclerView.addItemDecoration(new DividerItemDecoration(recyclerView.getContext(),
+                layoutManager.getOrientation()));
         // Inflate the layout for this fragment
         return view;
     }

--- a/app/src/main/java/com/allan/boardbuddies/fragments/NotesFragment.java
+++ b/app/src/main/java/com/allan/boardbuddies/fragments/NotesFragment.java
@@ -15,19 +15,22 @@ import com.allan.boardbuddies.Note;
 import com.allan.boardbuddies.NoteAdapter;
 import com.allan.boardbuddies.R;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import com.google.android.material.snackbar.Snackbar;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.ArrayList;
 
-/**
- * A simple {@link Fragment} subclass.
- *
- */
 public class NotesFragment extends Fragment {
     private ArrayList<Note> notes = new ArrayList<Note>();
     private RecyclerView recyclerView;
     private FloatingActionButton addNoteFab;
     private NoteAdapter adapter;
+
     public NotesFragment() {
         // Required empty public constructor
     }
@@ -36,6 +39,7 @@ public class NotesFragment extends Fragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Bundle bundle = getArguments();
+        loadNotes();
         if (bundle != null) {
             notes = (ArrayList<Note>)bundle.getSerializable("myNotes");
             // Handle the retrieved data as needed
@@ -67,5 +71,40 @@ public class NotesFragment extends Fragment {
                 view.getContext().startActivity(intent);
             }
         });
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        loadNotes();
+        adapter.notifyDataSetChanged();
+    }
+
+    private void loadNotes(){
+        File[] files = requireContext().getFilesDir().listFiles();
+        notes.clear();
+        for (File file : files){
+            if (file.isFile() && file.getName().endsWith(".json")) {
+                try {
+                    // Read the file contents
+                    BufferedReader reader = new BufferedReader(new FileReader(file));
+                    StringBuilder stringBuilder = new StringBuilder();
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        stringBuilder.append(line);
+                    }
+                    reader.close();
+
+                    // Parse the JSON content
+                    String jsonContent = stringBuilder.toString();
+                    JSONObject jsonObject = new JSONObject(jsonContent);
+
+                    // Add the parsed JSON content to the list
+                    notes.add(new Note((String) jsonObject.get("title"), (String) jsonObject.get("content")));
+                } catch (IOException | JSONException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/allan/boardbuddies/fragments/NotesFragment.java
+++ b/app/src/main/java/com/allan/boardbuddies/fragments/NotesFragment.java
@@ -25,8 +25,10 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 
-public class NotesFragment extends Fragment {
+public class NotesFragment extends Fragment implements NoteAdapter.OnNoteListener {
     private ArrayList<Note> notes = new ArrayList<Note>();
     private RecyclerView recyclerView;
     private FloatingActionButton addNoteFab;
@@ -41,10 +43,10 @@ public class NotesFragment extends Fragment {
         super.onCreate(savedInstanceState);
         Bundle bundle = getArguments();
         loadNotes();
-        if (bundle != null) {
-            notes = (ArrayList<Note>)bundle.getSerializable("myNotes");
-            // Handle the retrieved data as needed
-        }
+//        if (bundle != null) {
+//            notes = (ArrayList<Note>)bundle.getSerializable("myNotes");
+//            // Handle the retrieved data as needed
+//        }
     }
 
     @Override
@@ -55,7 +57,7 @@ public class NotesFragment extends Fragment {
         recyclerView = view.findViewById(R.id.main_recycler_view);
         LinearLayoutManager layoutManager = new LinearLayoutManager(view.getContext());
         recyclerView.setLayoutManager(layoutManager);
-        adapter = new NoteAdapter(notes);
+        adapter = new NoteAdapter(notes, this);
         recyclerView.setAdapter(adapter);
         recyclerView.addItemDecoration(new DividerItemDecoration(recyclerView.getContext(),
                 layoutManager.getOrientation()));
@@ -84,8 +86,18 @@ public class NotesFragment extends Fragment {
         adapter.notifyDataSetChanged();
     }
 
+    public void onNoteClick(int position){
+        Intent intent = new Intent(requireContext(), EditActivity.class);
+        intent.putExtra("TITLE", notes.get(position).getTitle());
+        intent.putExtra("CONTENT", notes.get(position).getContent());
+        intent.putExtra("NAME", notes.get(position).getName());
+        requireContext().startActivity(intent);
+        //
+    }
+
     private void loadNotes(){
-        File[] files = requireContext().getFilesDir().listFiles();
+        File[] files = getActivity().getApplicationContext().getFilesDir().listFiles();
+        Arrays.sort(files, Comparator.comparing(File::getName).reversed());
         notes.clear();
         for (File file : files){
             if (file.isFile() && file.getName().endsWith(".json")) {
@@ -104,7 +116,7 @@ public class NotesFragment extends Fragment {
                     JSONObject jsonObject = new JSONObject(jsonContent);
 
                     // Add the parsed JSON content to the list
-                    notes.add(new Note((String) jsonObject.get("title"), (String) jsonObject.get("content")));
+                    notes.add(new Note((String) jsonObject.get("title"), (String) jsonObject.get("content"), file.getName()));
                 } catch (IOException | JSONException e) {
                     e.printStackTrace();
                 }

--- a/app/src/main/java/com/allan/boardbuddies/fragments/NotesFragment.java
+++ b/app/src/main/java/com/allan/boardbuddies/fragments/NotesFragment.java
@@ -29,9 +29,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 public class NotesFragment extends Fragment implements NoteAdapter.OnNoteListener {
-    private ArrayList<Note> notes = new ArrayList<Note>();
-    private RecyclerView recyclerView;
-    private FloatingActionButton addNoteFab;
+    private ArrayList<Note> notes = new ArrayList<>();
     private NoteAdapter adapter;
 
     public NotesFragment() {
@@ -41,12 +39,7 @@ public class NotesFragment extends Fragment implements NoteAdapter.OnNoteListene
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Bundle bundle = getArguments();
         loadNotes();
-//        if (bundle != null) {
-//            notes = (ArrayList<Note>)bundle.getSerializable("myNotes");
-//            // Handle the retrieved data as needed
-//        }
     }
 
     @Override
@@ -54,7 +47,7 @@ public class NotesFragment extends Fragment implements NoteAdapter.OnNoteListene
                              Bundle savedInstanceState) {
 
         View view = inflater.inflate(R.layout.fragment_notes, container, false);
-        recyclerView = view.findViewById(R.id.main_recycler_view);
+        RecyclerView recyclerView = view.findViewById(R.id.main_recycler_view);
         LinearLayoutManager layoutManager = new LinearLayoutManager(view.getContext());
         recyclerView.setLayoutManager(layoutManager);
         adapter = new NoteAdapter(notes, this);
@@ -67,15 +60,10 @@ public class NotesFragment extends Fragment implements NoteAdapter.OnNoteListene
 
     @Override
     public void onViewCreated (View view, Bundle savedInstanceState){
-        addNoteFab = view.findViewById(R.id.add_note_fab);
-        addNoteFab.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-//                notes.add(new Note("yay", "bob"));
-//                adapter.notifyDataSetChanged();
-                Intent intent = new Intent(view.getContext(), EditActivity.class);
-                view.getContext().startActivity(intent);
-            }
+        FloatingActionButton addNoteFab = view.findViewById(R.id.add_note_fab);
+        addNoteFab.setOnClickListener(v -> {
+            Intent intent = new Intent(v.getContext(), EditActivity.class);
+            v.getContext().startActivity(intent);
         });
     }
 
@@ -96,28 +84,30 @@ public class NotesFragment extends Fragment implements NoteAdapter.OnNoteListene
 
     private void loadNotes(){
         File[] files = getActivity().getApplicationContext().getFilesDir().listFiles();
-        Arrays.sort(files, Comparator.comparing(File::getName).reversed());
         notes.clear();
-        for (File file : files){
-            if (file.isFile() && file.getName().endsWith(".json")) {
-                try {
-                    // Read the file contents
-                    BufferedReader reader = new BufferedReader(new FileReader(file));
-                    StringBuilder stringBuilder = new StringBuilder();
-                    String line;
-                    while ((line = reader.readLine()) != null) {
-                        stringBuilder.append(line);
+        if (files != null) {
+            Arrays.sort(files, Comparator.comparing(File::getName).reversed());
+            for (File file : files) {
+                if (file.isFile() && file.getName().endsWith(".json")) {
+                    try {
+                        // Read the file contents
+                        BufferedReader reader = new BufferedReader(new FileReader(file));
+                        StringBuilder stringBuilder = new StringBuilder();
+                        String line;
+                        while ((line = reader.readLine()) != null) {
+                            stringBuilder.append(line);
+                        }
+                        reader.close();
+
+                        // Parse the JSON content
+                        String jsonContent = stringBuilder.toString();
+                        JSONObject jsonObject = new JSONObject(jsonContent);
+
+                        // Add the parsed JSON content to the list
+                        notes.add(new Note((String) jsonObject.get("title"), (String) jsonObject.get("content"), file.getName()));
+                    } catch (IOException | JSONException e) {
+                        e.printStackTrace();
                     }
-                    reader.close();
-
-                    // Parse the JSON content
-                    String jsonContent = stringBuilder.toString();
-                    JSONObject jsonObject = new JSONObject(jsonContent);
-
-                    // Add the parsed JSON content to the list
-                    notes.add(new Note((String) jsonObject.get("title"), (String) jsonObject.get("content"), file.getName()));
-                } catch (IOException | JSONException e) {
-                    e.printStackTrace();
                 }
             }
         }

--- a/app/src/main/java/com/allan/boardbuddies/fragments/NotesFragment.java
+++ b/app/src/main/java/com/allan/boardbuddies/fragments/NotesFragment.java
@@ -90,9 +90,8 @@ public class NotesFragment extends Fragment implements NoteAdapter.OnNoteListene
         Intent intent = new Intent(requireContext(), EditActivity.class);
         intent.putExtra("TITLE", notes.get(position).getTitle());
         intent.putExtra("CONTENT", notes.get(position).getContent());
-        intent.putExtra("NAME", notes.get(position).getName());
+        intent.putExtra("FILENAME", notes.get(position).getName());
         requireContext().startActivity(intent);
-        //
     }
 
     private void loadNotes(){

--- a/app/src/main/res/layout/fragment_notes.xml
+++ b/app/src/main/res/layout/fragment_notes.xml
@@ -3,13 +3,16 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:paddingTop="5dp"
+    android:paddingBottom="5dp"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
     tools:context=".fragments.NotesFragment">
 
-    <!-- TODO: Update blank fragment layout -->
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/main_recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:theme="@style/Theme.Boardbuddies" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton

--- a/app/src/main/res/layout/note_item.xml
+++ b/app/src/main/res/layout/note_item.xml
@@ -6,6 +6,7 @@
         android:layout_height="wrap_content"
         android:maxLines="1"
         android:ellipsize="end"
-        android:textSize="18sp"
-        android:textColor="#808080"
-        android:padding="10dp"/>
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:paddingTop="11dp"
+        android:paddingBottom="11dp"/>


### PR DESCRIPTION
Description: Saves notes to internal storage as JSON {"title", "content} with file name as currentTimeMillis().
From my understanding, getFilesDir() is different depending on the context so I use getApplicationContext() to ensure app directory is used but it seems Activity context (edit/main) works too
Integrated NoteFragment and EditActivity, notes are sorted most recent edit first
Added + implemented OnNoteListener Interface for recyclerView onClick functionality

Is automated testing necessary and how?

Next step: delete note functionality and trash fragment, focus to end of edittext of content

Fig 1 shows when title is edited, fig 2 shows when only content is edited

https://github.com/allanfang1/boardbuddies/assets/32990185/7b23969c-7ec2-47f9-ab18-304a5b6096e8


https://github.com/allanfang1/boardbuddies/assets/32990185/ab1ce0c5-468e-41da-ab7e-d5b3a35059d8

